### PR TITLE
Add github action to deploy on push to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+# Workflow for building and deploying a React Static site to GitHub Pages
+name: Deploy
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build
+        run: |
+          cd site
+          make build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "site/dist"
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Mostly a basic deployment workflow. I just used `build` script from `Makefile`.
Decided not to use existing publish script because it's messing with cloning, branch creating, etc. To make this approach work we'll need to set up repo secrets with name/email and do many more unnecessary actions, so I went with a more common approach.

❗ To make these changes work, need to update the deployment setting of the repo (Settings -> Pages -> Build and Deployment -> Source:
![image](https://github.com/7guis/7guis/assets/30402802/54fe718c-1f8f-46b5-8dcb-3ae429bd5cfb)
Need to change it from `Deploy from a branch` to `Github Actions`.

After that we can do some clean up (remove publish script from Makefile, delete `gh-pages` branch).

Part of fix for #32 issue.